### PR TITLE
fix: resolve Vercel build dependency issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@radix-ui/react-dialog": "1.1.4",
         "@radix-ui/react-dropdown-menu": "2.1.4",
         "@radix-ui/react-hover-card": "1.1.4",
+        "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/react-label": "2.1.1",
         "@radix-ui/react-menubar": "1.1.4",
         "@radix-ui/react-navigation-menu": "1.2.3",
@@ -65,7 +66,7 @@
         "zod": "3.25.67"
       },
       "devDependencies": {
-        "@tailwindcss/postcss": "^4.1.9",
+        "@tailwindcss/postcss": "^4.1.13",
         "@types/node": "^22.18.6",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -804,6 +805,15 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@radix-ui/react-icons": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.2.tgz",
+      "integrity": "sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/@radix-ui/react-id": {
@@ -2105,6 +2115,7 @@
       "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.13.tgz",
       "integrity": "sha512-HLgx6YSFKJT7rJqh9oJs/TkBFhxuMOfUKSBEPYwV+t78POOBsdQ7crhZLzwcH3T0UyUuOzU/GK5pk5eKr3wCiQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "@tailwindcss/node": "4.1.13",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-dialog": "1.1.4",
     "@radix-ui/react-dropdown-menu": "2.1.4",
     "@radix-ui/react-hover-card": "1.1.4",
+    "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-label": "2.1.1",
     "@radix-ui/react-menubar": "1.1.4",
     "@radix-ui/react-navigation-menu": "1.2.3",
@@ -66,7 +67,7 @@
     "zod": "3.25.67"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4.1.9",
+    "@tailwindcss/postcss": "^4.1.13",
     "@types/node": "^22.18.6",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,4 @@
 {
-  "framework": "nextjs",
-  "buildCommand": "npm install --legacy-peer-deps && npm run build",
   "installCommand": "npm install --legacy-peer-deps",
   "env": {
     "NASA_API_KEY": "DEMO_KEY"


### PR DESCRIPTION
- Add missing @radix-ui/react-icons dependency
- Simplify vercel.json to use Vercel defaults for build process
- Use only installCommand with --legacy-peer-deps flag
- Remove custom buildCommand that may conflict with Next.js

🤖 Generated with [Claude Code](https://claude.ai/code)